### PR TITLE
assert in the style of part 4

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"strings"
 	"testing"
 )
@@ -11,6 +10,10 @@ func TestCli(t *testing.T) {
 	reader := strings.NewReader("insert 1 rob rob@example.com\nselect\n.exit\n")
 	out := bytes.Buffer{}
 	cli(reader, &out)
+	out.String()
 
-	fmt.Println("TODO: more test cases")
+	want := "db > statement executed.\ndb > &{1 rob rob@example.com}\nstatement executed.\ndb > adios!\n"
+	if out.String() != want {
+		t.Errorf("unexpected output")
+	}
 }


### PR DESCRIPTION
* fixes issue where we weren't writing to the `io.Writer` passed in from `main()` / test cases.
* updates assertion for match part 4's test case